### PR TITLE
Fix gallery alignment for single-image runs

### DIFF
--- a/templates/branch.html
+++ b/templates/branch.html
@@ -20,6 +20,7 @@
     .diff-summary-link a { font-weight: 600; }
     .gallery { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
       justify-items: center; gap: 1.5rem; }
+    .gallery:has(> :only-child) { justify-content: center; }
     figure { margin: 0; display: flex; flex-direction: column; align-items: center; }
     figure a { display: block; cursor: pointer; }
     figcaption { margin-top: 0.5rem; font-size: 0.9rem; word-break: break-word; }

--- a/templates/diff.html
+++ b/templates/diff.html
@@ -16,6 +16,7 @@
     .diff-empty { color: #586069; font-size: 0.95rem; margin-top: 1rem; }
     .gallery { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
       justify-items: center; gap: 1.5rem; }
+    .gallery:has(> :only-child) { justify-content: center; }
     figure { margin: 0; display: flex; flex-direction: column; align-items: center; }
     figure a { display: block; cursor: pointer; }
     figcaption { margin-top: 0.5rem; font-size: 0.9rem; word-break: break-word; }


### PR DESCRIPTION
### **User description**
## Summary
- Fixes misaligned gallery layout when only one image is present
- Uses CSS `:has(> :only-child)` selector to center single-item galleries
- Applied to both `branch.html` and `diff.html` templates

## Changes
- Added `justify-content: center` rule for galleries with a single child element
- This eliminates excess white space and properly centers the image with its caption

## Test plan
- [x] All existing tests pass
- [x] Visual verification: single-image galleries now center properly
- [x] Multi-image galleries remain unaffected (auto-fit grid behavior preserved)

Closes #3


___

### **PR Type**
Bug fix


___

### **Description**
- Fix gallery alignment for single-image displays

- Add CSS rule to center single-item galleries

- Apply fix to both branch and diff templates


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Gallery with single image"] --> B["CSS :has() selector"] --> C["Centered layout"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>branch.html</strong><dd><code>Add single-image gallery centering CSS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/branch.html

<ul><li>Add CSS rule <code>.gallery:has(> :only-child) { justify-content: center; }</code><br> <li> Fix alignment for single-image galleries</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/testboard/pull/8/files#diff-922c9542d1f9e7d154a966ad8a57a133c30f3ef32ef83feeac0a709053764d24">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>diff.html</strong><dd><code>Add single-image gallery centering CSS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/diff.html

<ul><li>Add CSS rule <code>.gallery:has(> :only-child) { justify-content: center; }</code><br> <li> Fix alignment for single-image galleries</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/testboard/pull/8/files#diff-c59fbd7fd72440650c3061e1788f4fc98816556eac10b4a32b0d18c215ef9196">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

